### PR TITLE
Ammending Get Command and Handling published Timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ This example will return a json object with following, note that as craftaro doe
 ## Methods
 * `#downloads(ids)` - Get the total downloads of a resource across multiple marketplaces.
 * `#rating(ids)` - Get the average rating and number of ratings of a resource across multiple marketplaces.
-* `#price(ids)` - Get the lowest price and lowest price currency of a resource across multiple marketplaces.
+* `#price(ids)` - Get the lowest price and lowest price currency of a resource across multiple marketplaces. 
 * `#latest_version(ids)` - Get the latest version name and published timestamp of a resource across multiple marketplaces.
 * `#name(ids)` - Get the name of a resource as it is listed on different marketplaces.
+* `#get(ids)` - Returns all available content from the above methods, and the aggregated data points available from each.
 
 ## Supported Marketplaces
 You can query the following marketplaces with this module. Note that not all marketplaces support returning data for every query.

--- a/src/mineget.ts
+++ b/src/mineget.ts
@@ -240,7 +240,7 @@ export async function latest_version(ids: Partial<PackagedMarkets>) {
             let latestVersionDate = 0;
             for (const [name, data] of Object.entries(res.endpoints)) {
                 let platformLatestVersionName = data.version;
-                let platformLatestVersionDate = typeof data.published === 'string' ? lodash.parseInt(data.published) : data.published;
+                let platformLatestVersionDate = typeof data.published === 'string' ? Date.parse(data.published) : data.published;
                 lodash.set(res, `endpoints.${name}.version`, platformLatestVersionName);
                 lodash.set(res, `endpoints.${name}.published`, (platformLatestVersionDate || '0'));
                 if (platformLatestVersionDate > latestVersionDate) {
@@ -273,6 +273,12 @@ export async function name(ids: Partial<PackagedMarkets>) {
             return Promise.reject(err);
         })
 }
+
+get({ spigot: 92672, craftaro: 622, github: "WiIIiam278/HuskTowns" })
+    .then(async (res) => {
+        console.log(res)
+    })
+
 
 export default {
     get,

--- a/src/mineget.ts
+++ b/src/mineget.ts
@@ -286,22 +286,18 @@ export async function name(ids: Partial<PackagedMarkets>) {
 
 const isDateString = (string: string) => {
     if (string.match(/^(?:(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?)?(?:T(\d{2}:\d{2})(?::(\d{2}))?(?:.(\d{3})|Z)?(?:(?:[+-])(\d{2}:\d{2}))?)?$/)) {
-        console.log('true')
         return true;
     }
     else {
-        console.log('false')
         return false;
     }
 }
 
 const isUnixString = (string: string) => {
     if (string.match(/^(\d{6,13})$/)) {
-        console.log('true');
         return true;
     }
     else {
-        console.log('false');
         return false;
     }
 }

--- a/src/mineget.ts
+++ b/src/mineget.ts
@@ -236,11 +236,21 @@ export async function rating(ids: Partial<PackagedMarkets>) {
 export async function latest_version(ids: Partial<PackagedMarkets>) {
     return query(ids, 'latest_version')
         .then((res) => {
+            console.log(res)
             let latestVersionName = '';
             let latestVersionDate = 0;
             for (const [name, data] of Object.entries(res.endpoints)) {
                 let platformLatestVersionName = data.version;
-                let platformLatestVersionDate = typeof data.published === 'string' ? Date.parse(data.published) : data.published;
+                let platformLatestVersionDate: number;
+                if (typeof data.published === 'string') {
+                    if (isDateString(data.published)) platformLatestVersionDate = Date.parse(data.published);
+                    else if (isUnixString(data.published)) platformLatestVersionDate = Number(data.published);
+                    else throw new Error(`Unknown date time string format received from ${name}`);
+                }
+                else {
+                    platformLatestVersionDate = data.published;
+                }
+                typeof data.published === 'string' ? Date.parse(data.published) : data.published
                 lodash.set(res, `endpoints.${name}.version`, platformLatestVersionName);
                 lodash.set(res, `endpoints.${name}.published`, (platformLatestVersionDate || '0'));
                 if (platformLatestVersionDate > latestVersionDate) {
@@ -274,11 +284,27 @@ export async function name(ids: Partial<PackagedMarkets>) {
         })
 }
 
-get({ spigot: 92672, craftaro: 622, github: "WiIIiam278/HuskTowns" })
-    .then(async (res) => {
-        console.log(res)
-    })
+const isDateString = (string: string) => {
+    if (string.match(/^(?:(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?)?(?:T(\d{2}:\d{2})(?::(\d{2}))?(?:.(\d{3})|Z)?(?:(?:[+-])(\d{2}:\d{2}))?)?$/)) {
+        console.log('true')
+        return true;
+    }
+    else {
+        console.log('false')
+        return false;
+    }
+}
 
+const isUnixString = (string: string) => {
+    if (string.match(/^(\d{6,13})$/)) {
+        console.log('true');
+        return true;
+    }
+    else {
+        console.log('false');
+        return false;
+    }
+}
 
 export default {
     get,

--- a/src/mineget.ts
+++ b/src/mineget.ts
@@ -129,6 +129,10 @@ export async function get(ids: Partial<PackagedMarkets>) {
         .then((res) => {
             return {
                 name: res[2].endpoints,
+                downloads: res[0].endpoints,
+                ratings: res[1].endpoints,
+                version: res[3].endpoints,
+                price: res[4].endpoints,
                 total_downloads: res[0].total_downloads,
                 average_rating: res[1].average_rating,
                 rating_count: res[1].rating_count,
@@ -206,8 +210,8 @@ export async function rating(ids: Partial<PackagedMarkets>) {
             let totalRating = 0;
             let totalRatingCount = 0;
             for (const [name, data] of Object.entries(res.endpoints)) {
-                if (typeof data.average !== 'number') data.average = -1;
-                if (typeof data.count !== 'number') data.count = -1;
+                if (typeof data.average !== 'number') data.average = 0;
+                if (typeof data.count !== 'number') data.count = 0;
                 let platformAverage = parseFloat(data.average.toString());
                 let platformCount = lodash.parseInt(data.count.toString());
                 lodash.set(res, `endpoints.${name}.average`, platformAverage);

--- a/src/mineget.ts
+++ b/src/mineget.ts
@@ -236,7 +236,6 @@ export async function rating(ids: Partial<PackagedMarkets>) {
 export async function latest_version(ids: Partial<PackagedMarkets>) {
     return query(ids, 'latest_version')
         .then((res) => {
-            console.log(res)
             let latestVersionName = '';
             let latestVersionDate = 0;
             for (const [name, data] of Object.entries(res.endpoints)) {


### PR DESCRIPTION
- Amends the #get(ids) command
  - This will return a larger data set from now on that includes all available methods data (when available) in its return value.
  - All endpoints are keyed by their marketplace name as usual.
  - The aggregated results from each are still available at the top level of the object.
- Handles timestamps for latest_version better
  - Market places like Github returns a Date Time String whereas others return a Unix timestamp, from here on all returns of the `#latest_version().published` property will be in a Unix timestamp format.
  - This is done via a Regex check for String returned Unix timestamps (such as those from Polymart) and a Date Time String Regex (such as those from Github).